### PR TITLE
Removed trailing comma

### DIFF
--- a/src/components/ExampleComponent.vue
+++ b/src/components/ExampleComponent.vue
@@ -10,7 +10,7 @@
 
         data: () => ({}),
 
-        computed: {},
+        computed: {}
     };
 </script>
 


### PR DESCRIPTION
I could be wrong, but I don't think JavaScript likes trailing commas.