### PR TITLE
Add testing environment variable

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,17 +1,21 @@
 {
-  "presets": [
-    ["env", {
-      "targets": {
-        "browsers": ["last 2 versions", "safari >= 7"]
-      },
-      "modules": "umd"
-    }]
-  ],
-  "plugins": [
-    "transform-object-rest-spread",
-    ["transform-runtime", {
-      "polyfill": false,
-      "regenerator": true
-    }]
-  ]
+  "env": {
+    "testing": {
+      "presets": [
+        ["env", {
+          "targets": {
+            "browsers": ["last 2 versions", "safari >= 7"]
+          },
+          "modules": "umd"
+        }]
+      ],
+      "plugins": [
+        "transform-object-rest-spread",
+        ["transform-runtime", {
+          "polyfill": false,
+          "regenerator": true
+        }]
+      ]
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "rm -rf dist && NODE_ENV=production webpack",
     "lint": "eslint --ext .js,.vue --fix src __tests__; exit 0",
     "prepublish": "npm run test; npm run build",
-    "test": "jest"
+    "test": "NODE_ENV=testing jest"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Thanks for the skeleton setup for testing! :+1: 

The default configuration results in issues when using in a Laravel project where the `.babelrc` config file gets picked up `laravel-mix` and causes all kinds of errors when building.

Limiting the scope of this configuration only for testing solves this. 

This pull request adds a `testing` environment variable and limits the `.babelrc` scope for this testing. 

I didn't check if it affects the build process (was not required in my case) but if it does, another more appropriate environment variable could be chosen which works for the scope of this config file.