### PR TITLE
Change loaders to be a strings instead of arrays

### DIFF
--- a/webpack.base.js
+++ b/webpack.base.js
@@ -3,12 +3,12 @@ module.exports = {
         rules: [
             {
                 test: /\.js/,
-                loaders: ['babel-loader'],
+                loader: 'babel-loader',
                 exclude: /node_modules/,
             },
             {
                 test: /\.vue$/,
-                loaders: ['vue-loader'],
+                loader: 'vue-loader',
                 exclude: /node_modules/,
             },
         ],


### PR DESCRIPTION
Hi there,

Thank you very much for this skeleton! 👍 This change swaps ```loaders``` for ```loader``` and puts both ```vue-loader``` and ```babel-loader``` in a string instead of an array since those are the only loaders being used for those rules. This allows you to specify additional options/loaders (e.g. scss/sass) for vue-loader:

```js
    test: /\.vue$/,
    loader: 'vue-loader',
    options: {
        loaders: {
            'scss': 'vue-style-loader!css-loader!sass-loader',
            'sass': 'vue-style-loader!css-loader!sass-loader?indentedSyntax'
        },
    },
```
If ```vue-loader``` is wrapped in an array you'd get the following error if you tried to specify options:

```js
Error: options/query cannot be used with loaders
```