### PR TITLE
Renames webpack library name

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = merge(require('./webpack.base'), {
     output: {
         path: path.resolve(__dirname, 'dist'),
         filename: 'index.js',
-        library: 'vue-tabs',
+        library: 'package_name',
         libraryTarget: 'umd',
     },
 


### PR DESCRIPTION
Renames webpack libray name to `package_name` so that it gets updated by
a find and replace per the README